### PR TITLE
kern.c: Update map declaration to have BTF support

### DIFF
--- a/src/kern.c
+++ b/src/kern.c
@@ -5,12 +5,15 @@
 #define SIGKILL 9
 
 // Data in this map is accessible in user-space
-struct bpf_map_def SEC("maps") kill_map = {
-      .type        = BPF_MAP_TYPE_HASH,
-      .key_size    = sizeof(long),
-      .value_size  = sizeof(char),
-      .max_entries = 64,
-};
+// The particular syntax with __uint() and __type() and the use of the .maps
+// section enable BTF for this map. For an example, "bpftool map dump" will
+// show the map structure.
+struct {
+  __uint(type, BPF_MAP_TYPE_HASH);
+  __type(key, long);
+  __type(value, char);
+  __uint(max_entries, 64);
+} kill_map SEC(".maps");
 
 // This is the tracepoint arguments of the kill functions
 // /sys/kernel/debug/tracing/events/syscalls/sys_enter_kill/format


### PR DESCRIPTION
Use the recent syntax specific to eBPF maps, and which allows for the creation of BTF information related to the map in the object file. With modern tooling this information can be loaded into the kernel when the map is created, such that we can later retrieve it. For example, we can get the following from bpftool:

    # bpftool map dump id 42
    [{
            "key": 340118,
            "value": 1
        }
    ]

Compare with the current version (no BTF):

    # bpftool map dump id 42
    key: 96 30 05 00 00 00 00 00  value: 01
    Found 1 element

It is not visible in this example, but the terms `key` and `value` in the version with BTF support are those that we used in the kernel program. In the version with no BTF, they are simply generic terms used by bpftool (they happen to be the same words), but they won't change if you have a different map, with different name for the fields or with structs for the type of the keys/values. 

BTF support for eBPF programs is already present through the `-g` flag used to compile the program.