### PR TITLE
Resolves #11: Updates libbpf to 1.2

### DIFF
--- a/src/kern.c
+++ b/src/kern.c
@@ -1,6 +1,7 @@
 /*
- * This file is part of the ebpf-kill-example distribution (https://github.com/niclashedam/ebpf-kill-example).
- * Copyright (c) 2021 Niclas Hedam.
+ * This file is part of the ebpf-kill-example distribution
+ * (https://github.com/niclashedam/ebpf-kill-example). Copyright (c) 2021 Niclas
+ * Hedam.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
A lot of things have happened since I wrote _ebpf-kill-example_. It is now time to revisit libbpf and make sure this example is still up-to-date and relevant.

This PR rewrites `user.c` to match the newest interface. Tests pass, and `kern.c` is unchanged.